### PR TITLE
Update project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject migratus-lein "0.5.4"
+(defproject migratus-lein "0.5.5"
   :description "Maintain database migrations."
   :url "http://github.com/pjstadig/migratus-lein"
   :license {:name "Apache License, Version 2.0"
@@ -7,5 +7,5 @@
   :eval-in-leiningen true
   :aliases {"test!" ["do" "clean," "test"]}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [migratus "1.0.2"]]
+                 [migratus "1.0.3"]]
   :profiles {:dev {:dependencies [[jar-migrations "1.0.0"]]}})


### PR DESCRIPTION
Bump version to pickup migratus 1.0.3 for the JDK 9 fixes